### PR TITLE
Revert "Bump coffee-loader from 0.7.3 to 0.8.0 (#82)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.0",
-    "coffee-loader": "^0.8.0",
+    "coffee-loader": "^0.7.3",
     "coffee-script": "^1.12.7",
     "compression-webpack-plugin": "^1.0.0",
     "css-loader": "^0.28.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1153,9 +1153,9 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-coffee-loader@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/coffee-loader/-/coffee-loader-0.8.0.tgz#ec48e7327da8e3a99047a99d9bdcfcac12df3694"
+coffee-loader@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/coffee-loader/-/coffee-loader-0.7.3.tgz#fadbc6efd6fc7ecc88c5b3046a2c292066bcb54a"
   dependencies:
     loader-utils "^1.0.2"
 


### PR DESCRIPTION
This reverts commit 93a52d4ce8830fcf806083129f45418ba6927bbd.

fixes #

### Summary

### Other Information
