### PR TITLE
Fix side nav link

### DIFF
--- a/app/views/shared/_side_nav.html.haml
+++ b/app/views/shared/_side_nav.html.haml
@@ -14,7 +14,7 @@
   %hr
   %ul
     - (@latest_posts || @posts).each do |post|
-      = link_to blog_posts_path(post) do
+      = link_to blog_post_path(post) do
         %li= post.title
           %p= post.description
 %ArchiveList{ id: 'archive-list', data: { archives: @archives.to_json } }


### PR DESCRIPTION
### Summary
`blog_posts_path(post)` returns /blog/posts/page/{post_id}
